### PR TITLE
improved exports map for old version of node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 .DS_Store
 dist
 *.log
+vite.*
+rollup.*
+esbuild.*

--- a/package.json
+++ b/package.json
@@ -6,29 +6,27 @@
   "license": "MIT",
   "files": [
     "dist",
-    "types.d.ts"
+    "types.d.ts",
+    "vite.*",
+    "rollup.*",
+    "esbuild.*"
   ],
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/types.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },
     "./vite": {
-      "types": "./dist/vite.d.ts",
       "require": "./dist/vite.js",
       "import": "./dist/vite.mjs"
     },
     "./rollup": {
-      "types": "./dist/rollup.d.ts",
       "require": "./dist/rollup.js",
       "import": "./dist/rollup.mjs"
     },
     "./esbuild": {
-      "types": "./dist/esbuild.d.ts",
       "require": "./dist/esbuild.js",
       "import": "./dist/esbuild.mjs"
     },

--- a/scripts/postbuild.mts
+++ b/scripts/postbuild.mts
@@ -1,7 +1,9 @@
-import { basename, dirname, resolve } from 'path'
+import { basename, dirname, join, relative, resolve } from 'path/posix'
 import { readFile, writeFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import fg from 'fast-glob'
+import { exports as exportMap } from "../package.json";
+import { mkdirSync, writeFileSync } from 'node:fs';
 
 // fix cjs exports
 const files = await fg('*.js', {
@@ -16,4 +18,36 @@ for (const file of files) {
   code = code.replace('exports.default =', 'module.exports =')
   code += 'exports.default = module.exports;'
   await writeFile(file, code)
+}
+
+const ROOT_PATH = dirname(fileURLToPath(import.meta.url))
+for (const ex of Object.keys(exportMap)) {
+  const file = exportMap[ex as keyof typeof exportMap];
+  if (ex === '.' || typeof file==='string' || !file.require) {
+    continue
+  }
+
+  const [, ...folders] = ex.split('/')
+  const fileName = folders.pop()
+
+  const [, ...targetFolders] = file.require.split('/')
+  const targetFileName = targetFolders.pop()
+  const target = relative(
+    join(ROOT_PATH, ...folders),
+    join(ROOT_PATH, ...targetFolders, targetFileName!),
+  )
+
+  mkdirSync(join(ROOT_PATH, ...folders), {
+    recursive: true,
+  })
+
+  writeFileSync(
+    join(ROOT_PATH, ...folders, `${fileName}.js`),
+    `module.exports = require('./${target}')`,
+  )
+
+  writeFileSync(
+    join(ROOT_PATH, ...folders, `${fileName}.d.ts`),
+    `export * from './${target.split('.')[0]}'`,
+  )
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When set `moduleResolution: "node"` in `tsconfig.json`, the `exports` in package.json will not effect.

test in https://arethetypeswrong.github.io/?p=vue-functional-ref

So just add physical file map

Also, the type in `exports` will auto infer by file name, so maybe no need to set?
